### PR TITLE
Removed redundant lines

### DIFF
--- a/src/basinSubModelList.c
+++ b/src/basinSubModelList.c
@@ -36,10 +36,7 @@ void loadBasinResources(global_model_parameters *GLOBAL_MODEL_PARAMETERS)
         {
             load_Canterbury_Pre_Quaternary_v18p3(GLOBAL_MODEL_PARAMETERS,i);
         }
-        else if (strcmp(GLOBAL_MODEL_PARAMETERS->basin[i],"Canterbury_Pre_Quaternary_v18p4") == 0)
-        {
-            load_Canterbury_Pre_Quaternary_v18p4(GLOBAL_MODEL_PARAMETERS,i);
-        }
+
          // ============
          // v19p1 models
          // ============
@@ -857,38 +854,6 @@ void load_Canterbury_Pre_Quaternary_v18p3(global_model_parameters *GLOBAL_MODEL_
     GLOBAL_MODEL_PARAMETERS->basinBoundaryNumber[basinNum][4] = 0;
 }
 
-void load_Canterbury_Pre_Quaternary_v18p4(global_model_parameters *GLOBAL_MODEL_PARAMETERS, int basinNum)
-{
-    GLOBAL_MODEL_PARAMETERS->ignoreBasinForSmoothing[basinNum] = 0;
-    // CANTERBURY Basin (1D above basement)
-    GLOBAL_MODEL_PARAMETERS->nBasinSurfaces[basinNum] = 5;
-    GLOBAL_MODEL_PARAMETERS->nBasinBoundaries[basinNum] = 1;
-    GLOBAL_MODEL_PARAMETERS->basinBoundaryFilenames[basinNum][0] = "Data/Boundaries/NewCanterburyBasinBoundary_WGS84_1m.txt";
-    
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceNames[basinNum][0] = "DEM";
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceFilenames[basinNum][0] = "Data/DEM/DEM.in";
-    GLOBAL_MODEL_PARAMETERS->basinBoundaryNumber[basinNum][0] = 0;
-    GLOBAL_MODEL_PARAMETERS->basinSubModelNames[basinNum][0] = "Cant1D_v2_Pliocene_Enforced";
-    
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceNames[basinNum][1] = "PlioceneTop";
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceFilenames[basinNum][1] = "Data/Canterbury_Basin/Pre_Quaternary/Pliocene_46_v8p9p18.in";
-    GLOBAL_MODEL_PARAMETERS->basinBoundaryNumber[basinNum][1] = 0;
-    GLOBAL_MODEL_PARAMETERS->basinSubModelNames[basinNum][1] = "PlioceneSubMod_v1";
-    
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceNames[basinNum][2] = "MioceneTop";
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceFilenames[basinNum][2] = "Data/Canterbury_Basin/Pre_Quaternary/MioceneTop.in";
-    GLOBAL_MODEL_PARAMETERS->basinBoundaryNumber[basinNum][2] = 0;
-    GLOBAL_MODEL_PARAMETERS->basinSubModelNames[basinNum][2] = "MioceneSubMod_v1";
-    
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceNames[basinNum][3] = "PaleogeneTop";
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceFilenames[basinNum][3] = "Data/Canterbury_Basin/Pre_Quaternary/PaleogeneTop.in";
-    GLOBAL_MODEL_PARAMETERS->basinBoundaryNumber[basinNum][3] = 0;
-    GLOBAL_MODEL_PARAMETERS->basinSubModelNames[basinNum][3] = "PaleogeneSubMod_v1";
-    
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceNames[basinNum][4] = "BasementTopSurf";
-    GLOBAL_MODEL_PARAMETERS->basinSurfaceFilenames[basinNum][4] = "Data/Canterbury_Basin/Quaternary/BasementTop.in";
-    GLOBAL_MODEL_PARAMETERS->basinBoundaryNumber[basinNum][4] = 0;
-}
 
 void load_WaikatoHauraki_v19p7(global_model_parameters *GLOBAL_MODEL_PARAMETERS, int basinNum)
 {

--- a/src/functions.h
+++ b/src/functions.h
@@ -275,8 +275,6 @@ extern void offShoreBasinModel(double shorelineDist, double dep, qualities_vecto
 void load_Canterbury_Pre_Quaternary_v18p1(global_model_parameters *GLOBAL_MODEL_PARAMETERS, int basinNum);
 void load_Canterbury_Pre_Quaternary_v18p2(global_model_parameters *GLOBAL_MODEL_PARAMETERS, int basinNum);
 void load_Canterbury_Pre_Quaternary_v18p3(global_model_parameters *GLOBAL_MODEL_PARAMETERS, int basinNum);
-void load_Canterbury_Pre_Quaternary_v18p4(global_model_parameters *GLOBAL_MODEL_PARAMETERS, int basinNum);
-
 
 
 // v19p1 Models

--- a/src/getSurfSubModNames.c
+++ b/src/getSurfSubModNames.c
@@ -1356,20 +1356,6 @@ global_model_parameters *getGlobalModelParameters(char *modelVersion, char *TOPO
     else if(strcmp(modelVersion,"1.64") == 0)
     {
         // define the number of surfaces and sub models
-        GLOBAL_MODEL_PARAMETERS->nSurf = 2;
-        GLOBAL_MODEL_PARAMETERS->nVeloSubMod = 1;
-        
-        // insert surface surface keywords and filenames
-        GLOBAL_MODEL_PARAMETERS->surf[0] = "posInfSurf";
-        GLOBAL_MODEL_PARAMETERS->globalSurfFilenames[0] = "Data/Global_Surfaces/posInf.in";
-        GLOBAL_MODEL_PARAMETERS->surf[1] = "negInfSurf";
-        GLOBAL_MODEL_PARAMETERS->globalSurfFilenames[1] = "Data/Global_Surfaces/negInf.in";
-        
-        // insert velocity submodel keywords and filenames (if necessary)
-        GLOBAL_MODEL_PARAMETERS->veloSubMod[0] = "EPtomo2010subMod";
-        GLOBAL_MODEL_PARAMETERS->tomographyName = "2010_Full_South_Island";
-        
-        // define the number of surfaces and sub models
         GLOBAL_MODEL_PARAMETERS->nSurf = 3;
         GLOBAL_MODEL_PARAMETERS->nVeloSubMod = 2;
         

--- a/src/getSurfSubModNames.c
+++ b/src/getSurfSubModNames.c
@@ -1451,7 +1451,7 @@ global_model_parameters *getGlobalModelParameters(char *modelVersion, char *TOPO
         GLOBAL_MODEL_PARAMETERS->tomographyName = "2010_NZ";
         
         GLOBAL_MODEL_PARAMETERS->nBasins = 2;
-        GLOBAL_MODEL_PARAMETERS->basin[0] = "Canterbury_Pre_Quaternary_v18p4";
+        GLOBAL_MODEL_PARAMETERS->basin[0] = "Canterbury_Pre_Quaternary_v18p3";
         GLOBAL_MODEL_PARAMETERS->basin[1] = "Banks_Peninsula_Volcanics_v19p1";
         
         GLOBAL_MODEL_PARAMETERS->GTL = 1;


### PR DESCRIPTION
Came across this one while reading the code 

From the readme, it reads,

> v1.64 Same as v1.63 with updated 1D velocity model
> 1D model version (Cant1D_v2.fd_modfile)

But there are actually 2 additional differences between two versions.

1. BPVSubMod_v3 -> BPVSubMod_v4 (see load_Banks_Peninsula_Volcanics_v19p1())
2. v1.64 has an additional surface and veloSubMod

If 2 is not intended, the lines I removed in this PR must be brought back, and lines assuming nSurf=3 and nVeloSubMod=2 should be removed instead. 