### PR TITLE
Updated gcc-8 to gcc-11 to support openmp on Mac

### DIFF
--- a/src/makefile.mac
+++ b/src/makefile.mac
@@ -1,6 +1,6 @@
 TARGET = NZVM
 LIBS = -lm
-CC = gcc-8
+CC = gcc-11
 CFLAGS = -std=c99 -g -Wall -O3 -fopenmp #-D_AIX
 
 .PHONY: default all clean


### PR DESCRIPTION
Compiling OpenMP could be a challenge on Mac if you have an old gcc.

```
(sungbae@ringo):(~/Velocity-Model)
(!547) $ make mac
cd src; make -f makefile.mac
gcc-8 -std=c99 -g -Wall -O3 -fopenmp  -c BrocherCorrelations.c -o BrocherCorrelations.o
clang: error: unsupported option '-fopenmp'
make[1]: *** [BrocherCorrelations.o] Error 1
make: *** [mac] Error 2
```

After upgrading to gcc-11 
```
(!549) $ make mac
cd src; make -f makefile.mac
gcc-11 -std=c99 -g -Wall -O3 -fopenmp  -c BrocherCorrelations.c -o BrocherCorrelations.o
gcc-11 -std=c99 -g -Wall -O3 -fopenmp  -c EPtomo2010subMod.c -o EPtomo2010subMod.o
...
mv NZVM ..
```