### PR TITLE
Added readParameterNoExit() to handle optional parameters

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -85,6 +85,7 @@ extern gen_extract_velo_mod_call readGenerateThresholdUserInputTextFile(char *fi
 extern gen_extract_multi_gridpoint_vs_call readExtractMultiInputTextFile(char *fileName);
 extern multi_profile_parameters *readProfilesTextFile(char *fileName);
 extern char *readParameter(char *fileName, char *quality);
+extern char *readParameterNoExit(char *fileName, char *quality);
 
 
 

--- a/src/loadSurface.c
+++ b/src/loadSurface.c
@@ -139,6 +139,11 @@ basin_surf_read *loadBasinSurface(char *fileName)
 
     basin_surf_read *BASIN_SURF_READ;
     BASIN_SURF_READ = malloc(sizeof(basin_surf_read));
+    if (BASIN_SURF_READ == NULL)
+    {
+        printf("Error: malloc failed while loading %s\n", fileName);
+        exit(EXIT_FAILURE);
+    }
     
     int nLat, nLon;
     // read and assign the number of latitude and longitude values

--- a/src/readWriteInputFiles.c
+++ b/src/readWriteInputFiles.c
@@ -184,45 +184,51 @@ void writeSampleInputTextFiles(void)
 
 char *readParameter(char *fileName, char *quality)
 {
+    returnValue = readParameterNoExit(fileName,quality);
+
+    if (returnValue == NULL)
+    {
+        printf("Quality %s not set in file %s. See readme.\n",quality,fileName);
+        exit(EXIT_FAILURE);
+    }
+    return returnValue;
+}
+
+char *readParameterNoExit(char *fileName, char *quality) {
     char line[MAX_FILENAME_STRING_LEN];
-    char *returnValue=(char*) malloc(MAX_FILENAME_STRING_LEN*sizeof(char));
+    char *returnValue = (char *) malloc(MAX_FILENAME_STRING_LEN * sizeof(char));
     char *type;
     char *val;
     int valAssigned = 0;
 
     FILE *fNameRead = NULL;
-    fNameRead  = fopen(fileName, "r");
-    if (fNameRead == NULL)
-    {
-        printf("File not found. (%s).\n",fileName);
+    fNameRead = fopen(fileName, "r");
+    if (fNameRead == NULL) {
+        printf("File not found. (%s).\n", fileName);
         exit(EXIT_FAILURE);
     }
 
-    while (fgets (line, sizeof(line), fNameRead))
-    {
-        type = strtok (line,"=");
-        val = strtok (NULL,"=");
-        if(strcmp(type, quality) == 0)
-        {
-            val[strlen(val)-1] = 0;
-            strcpy(returnValue,val);
+    while (fgets(line, sizeof(line), fNameRead)) {
+        type = strtok(line, "=");
+        val = strtok(NULL, "=");
+        if (strcmp(type, quality) == 0) {
+            val[strlen(val) - 1] = 0;
+            strcpy(returnValue, val);
 //            printf("%s %s\n",type, val);
             valAssigned = 1;
             break;
-
         }
     }
+    fclose(fNameRead);
+
     if (valAssigned == 0)
     {
-        printf("Quality %s not set in file %s. See readme.\n",quality,fileName);
-        exit(EXIT_FAILURE);
+        returnValue = NULL;
     }
-    fclose(fNameRead);
     return returnValue;
 }
 
-
-gen_extract_velo_mod_call readGenVMInputTextFile(char *fileName, int rank)
+        gen_extract_velo_mod_call readGenVMInputTextFile(char *fileName, int rank)
 {
 
    gen_extract_velo_mod_call GEN_EXTRACT_VELO_MOD_CALL;
@@ -242,8 +248,8 @@ gen_extract_velo_mod_call readGenVMInputTextFile(char *fileName, int rank)
        GEN_EXTRACT_VELO_MOD_CALL.MIN_VS = atof(readParameter(fileName,"MIN_VS"));
        GEN_EXTRACT_VELO_MOD_CALL.TOPO_TYPE = readParameter(fileName,"TOPO_TYPE");
        topo_type_string_length = strnlen(GEN_EXTRACT_VELO_MOD_CALL.TOPO_TYPE, 200);
-       char *model_format=readParameter(fileName,"MODEL_FORMAT");
        GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 0;
+       char *model_format=readParameterNoExit(fileName,"MODEL_FORMAT");
        if (strcmp(model_format, "AWP") == 0) GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 1;
    }
 
@@ -300,7 +306,7 @@ gen_extract_velo_mod_call readExtractVMInputTextFile(char *fileName)
 gen_velo_slices_call readGenerateSliceInputTextFile(char *fileName)
 {
     gen_velo_slices_call GEN_VELO_SLICES_CALL;
-    GEN_VELO_SLICES_CALL.GENERATED_SLICE_PARAMETERS_TEXTFILE = readParameter(fileName,"GENERATED_SLICE_PARAMETERS_TEXTFILE");
+    GEN_VELO_SLICES_CALL.GENERATED_SLICE_PARAMETERS_TEXTFILE = readParameter(fileName,"GENERATED_SLICE_PARAMETERS_TEXTFILE";
     GEN_VELO_SLICES_CALL.TOPO_TYPE = readParameter(fileName,"TOPO_TYPE");
 
     return GEN_VELO_SLICES_CALL;

--- a/src/readWriteInputFiles.c
+++ b/src/readWriteInputFiles.c
@@ -224,6 +224,7 @@ char *readParameterNoExit(char *fileName, char *quality) {
 
     if (valAssigned == 0)
     {
+        free(returnValue);
         returnValue = NULL;
     }
     return returnValue;

--- a/src/readWriteInputFiles.c
+++ b/src/readWriteInputFiles.c
@@ -252,7 +252,7 @@ char *readParameterNoExit(char *fileName, char *quality) {
        topo_type_string_length = strnlen(GEN_EXTRACT_VELO_MOD_CALL.TOPO_TYPE, 200);
        GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 0;
        char *model_format=readParameterNoExit(fileName,"MODEL_FORMAT");
-       if (model_format !=NULL && strcmp(model_format, "AWP") == 0) GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 1;
+       if (model_format != NULL && strcmp(model_format, "AWP") == 0) GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 1;
 
    }
 

--- a/src/readWriteInputFiles.c
+++ b/src/readWriteInputFiles.c
@@ -184,6 +184,7 @@ void writeSampleInputTextFiles(void)
 
 char *readParameter(char *fileName, char *quality)
 {
+    char *returnValue;
     returnValue = readParameterNoExit(fileName,quality);
 
     if (returnValue == NULL)
@@ -250,7 +251,8 @@ char *readParameterNoExit(char *fileName, char *quality) {
        topo_type_string_length = strnlen(GEN_EXTRACT_VELO_MOD_CALL.TOPO_TYPE, 200);
        GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 0;
        char *model_format=readParameterNoExit(fileName,"MODEL_FORMAT");
-       if (strcmp(model_format, "AWP") == 0) GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 1;
+       if (model_format !=NULL && strcmp(model_format, "AWP") == 0) GEN_EXTRACT_VELO_MOD_CALL.AWP_OUTPUT = 1;
+
    }
 
    MPI_Bcast(&GEN_EXTRACT_VELO_MOD_CALL.ORIGIN_LAT, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
@@ -306,7 +308,7 @@ gen_extract_velo_mod_call readExtractVMInputTextFile(char *fileName)
 gen_velo_slices_call readGenerateSliceInputTextFile(char *fileName)
 {
     gen_velo_slices_call GEN_VELO_SLICES_CALL;
-    GEN_VELO_SLICES_CALL.GENERATED_SLICE_PARAMETERS_TEXTFILE = readParameter(fileName,"GENERATED_SLICE_PARAMETERS_TEXTFILE";
+    GEN_VELO_SLICES_CALL.GENERATED_SLICE_PARAMETERS_TEXTFILE = readParameter(fileName,"GENERATED_SLICE_PARAMETERS_TEXTFILE");
     GEN_VELO_SLICES_CALL.TOPO_TYPE = readParameter(fileName,"TOPO_TYPE");
 
     return GEN_VELO_SLICES_CALL;


### PR DESCRIPTION
A new parameter MODEL_FORMAT=AWP|GENERIC was introduced with the MPI implementation.
However, the existing readParameter() function processing nzvm.cfg, by default, terminates the binary if the parameter is not found.0
This is not an ideal behaviour if we have an old vm_params.yaml (or nzvm.cfg) that doesn't have this parameter.
As C oesn't support an optional argument, I implemented a separate function readParameterNoExit() that simply returns NULL if the requested parameter is not found.

Also added a malloc() failure check.