### PR TITLE
Both Z1.0 and Z2.5 are computed by default

### DIFF
--- a/Velocity_Model/basins.py
+++ b/Velocity_Model/basins.py
@@ -20,7 +20,6 @@ def get_basin_files_for_a_version(ver):
         print(f"Empty - check version {ver}")
     return flat_files
 
-
 versions = ["2.03", "2.04", "2.05", "2.06", "2.07"]
 basin_outlines_dict = {}
 prev_ver_basins = []

--- a/Velocity_Model/scripts/get_z.py
+++ b/Velocity_Model/scripts/get_z.py
@@ -6,15 +6,16 @@ from Velocity_Model.z import extract_z, basin_outlines_dict
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-ll", help="Station ll file", required=True)
+    parser.add_argument("-ll", help="Station ll file", required=True, type=Path)
     parser.add_argument(
         "-z",
-        "--z-type",
+        "--z-types",
         choices=[
             "Z1.0",
             "Z2.5",
         ],  # TO DO:["vs30", "vs500"] not working despite documentation saying otherwise
         help="Selects what Z type to extract: [%(choices)s]",
+        action="extend",
         nargs="+",
         required=True,
     )
@@ -33,12 +34,18 @@ if __name__ == "__main__":
         default=True,
         action="store_false",
     )
-    parser.add_argument("-o", "--output", help="path to output file", default=".", type=Path)
+    parser.add_argument("-o", "--outdir", help="output directory", default=Path.cwd(), type=Path)
     parser.add_argument("--nzvm-path", default="NZVM", type=Path)
     args = parser.parse_args()
 
     stat_df = formats.load_station_file(args.ll)
 
-    output_file = args.output
-    z_df = extract_z(args.z_type, stat_df, args.nzvm_path, args.version)
+    print(args.outdir)
+    output_file = args.outdir / args.ll.with_suffix(".z").name
+
+    print(f"Specified z-types : {args.z_types}")
+    print(f"Output to be saved as {output_file}")
+
+    z_df = extract_z(args.z_types, stat_df, args.nzvm_path, args.version)
+    print(z_df)
     z_df.to_csv(output_file,header=args.keep_header)

--- a/Velocity_Model/scripts/get_z.py
+++ b/Velocity_Model/scripts/get_z.py
@@ -26,7 +26,9 @@ if __name__ == "__main__":
     )
     # by default, the output file will be current_dir / {ll_file}.z
     # this is to avoid overwriting existing z-file in StationInfo directory by mistake
-    parser.add_argument("-o", "--outdir", help="output directory", default=Path.cwd(), type=Path)
+    parser.add_argument(
+        "-o", "--outdir", help="output directory", default=Path.cwd(), type=Path
+    )
     parser.add_argument("--nzvm-path", default="NZVM", type=Path)
     args = parser.parse_args()
 
@@ -39,4 +41,4 @@ if __name__ == "__main__":
 
     z_df = extract_z(z_types, stat_df, args.nzvm_path, args.version)
     print(z_df)
-    z_df.to_csv(output_file,header=args.keep_header)
+    z_df.to_csv(output_file, header=args.keep_header)

--- a/Velocity_Model/scripts/get_z.py
+++ b/Velocity_Model/scripts/get_z.py
@@ -2,23 +2,13 @@ import argparse
 from pathlib import Path
 
 from qcore import formats
-from Velocity_Model.z import extract_z, basin_outlines_dict 
+from Velocity_Model.z import extract_z, basin_outlines_dict
+
+z_types = ["Z1.0", "Z2.5"]
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-ll", help="Station ll file", required=True, type=Path)
-    parser.add_argument(
-        "-z",
-        "--z-types",
-        choices=[
-            "Z1.0",
-            "Z2.5",
-        ],  # TO DO:["vs30", "vs500"] not working despite documentation saying otherwise
-        help="Selects what Z type to extract: [%(choices)s]",
-        action="extend",
-        nargs="+",
-        required=True,
-    )
     vm_versions = basin_outlines_dict.keys()
     parser.add_argument(
         "-v",
@@ -34,6 +24,8 @@ if __name__ == "__main__":
         default=True,
         action="store_false",
     )
+    # by default, the output file will be current_dir / {ll_file}.z
+    # this is to avoid overwriting existing z-file in StationInfo directory by mistake
     parser.add_argument("-o", "--outdir", help="output directory", default=Path.cwd(), type=Path)
     parser.add_argument("--nzvm-path", default="NZVM", type=Path)
     args = parser.parse_args()
@@ -43,9 +35,8 @@ if __name__ == "__main__":
     print(args.outdir)
     output_file = args.outdir / args.ll.with_suffix(".z").name
 
-    print(f"Specified z-types : {args.z_types}")
     print(f"Output to be saved as {output_file}")
 
-    z_df = extract_z(args.z_types, stat_df, args.nzvm_path, args.version)
+    z_df = extract_z(z_types, stat_df, args.nzvm_path, args.version)
     print(z_df)
     z_df.to_csv(output_file,header=args.keep_header)

--- a/Velocity_Model/scripts/get_z.py
+++ b/Velocity_Model/scripts/get_z.py
@@ -34,11 +34,11 @@ if __name__ == "__main__":
 
     stat_df = formats.load_station_file(args.ll)
 
-    print(args.outdir)
     output_file = args.outdir / args.ll.with_suffix(".z").name
 
     print(f"Output to be saved as {output_file}")
 
     z_df = extract_z(z_types, stat_df, args.nzvm_path, args.version)
+    # this print is intentional. gives a peek view of the result
     print(z_df)
     z_df.to_csv(output_file, header=args.keep_header)

--- a/Velocity_Model/z.py
+++ b/Velocity_Model/z.py
@@ -63,12 +63,14 @@ def extract_z(
             )
 
             for z_type in z_types:
+                print(z_type)
                 z_val = calculate_z(
                         config_ffp, coords_ffp, nzvm_path, version, vm_working_dir, z_type)
                 if z_type in z_values:
                     z_val.index = range(z_values[z_type].index.max() + 1,
                                         z_values[z_type].index.max() + n_stats_slice + 1)
-                    z_values[z_type] = z_values[z_type].append(z_val)
+#                    z_values[z_type] = z_values[z_type].append(z_val)
+                    z_values[z_type] = pd.concat([z_values[z_type], z_val], ignore_index=True)
                 else:
                     z_values[z_type] = z_val
 

--- a/Velocity_Model/z.py
+++ b/Velocity_Model/z.py
@@ -53,7 +53,7 @@ def extract_z(
             coords_ffp = temp_dir / "MultipleProfileParameters.txt"
             vm_working_dir = temp_dir / "z_output"
 
-            stat_df_slice = stat_df[i: i + SLICE_SIZE]
+            stat_df_slice = stat_df[i : i + SLICE_SIZE]
 
             n_stats_slice = len(stat_df_slice)
             with open(coords_ffp, "w") as coords_fp:
@@ -64,17 +64,24 @@ def extract_z(
 
             for z_type in z_types:
                 z_val = calculate_z(
-                        config_ffp, coords_ffp, nzvm_path, version, vm_working_dir, z_type)
+                    config_ffp, coords_ffp, nzvm_path, version, vm_working_dir, z_type
+                )
                 if z_type in z_values:
-                    z_val.index = range(z_values[z_type].index.max() + 1,
-                                        z_values[z_type].index.max() + n_stats_slice + 1)
-                    z_values[z_type] = pd.concat([z_values[z_type], z_val], ignore_index=True)
+                    z_val.index = range(
+                        z_values[z_type].index.max() + 1,
+                        z_values[z_type].index.max() + n_stats_slice + 1,
+                    )
+                    z_values[z_type] = pd.concat(
+                        [z_values[z_type], z_val], ignore_index=True
+                    )
                 else:
                     z_values[z_type] = z_val
 
     for z_type in z_types:
         stat_df["z_index"] = z_values[z_type].index
-        merged_df = merged_df.merge(z_values[z_type], left_on="z_index", right_index=True)
+        merged_df = merged_df.merge(
+            z_values[z_type], left_on="z_index", right_index=True
+        )
 
     merged_df["sigma"] = calculate_z_sigma(stat_df, version)
 

--- a/Velocity_Model/z.py
+++ b/Velocity_Model/z.py
@@ -63,13 +63,11 @@ def extract_z(
             )
 
             for z_type in z_types:
-                print(z_type)
                 z_val = calculate_z(
                         config_ffp, coords_ffp, nzvm_path, version, vm_working_dir, z_type)
                 if z_type in z_values:
                     z_val.index = range(z_values[z_type].index.max() + 1,
                                         z_values[z_type].index.max() + n_stats_slice + 1)
-#                    z_values[z_type] = z_values[z_type].append(z_val)
                     z_values[z_type] = pd.concat([z_values[z_type], z_val], ignore_index=True)
                 else:
                     z_values[z_type] = z_val


### PR DESCRIPTION
Previously, it was designed to select either Z1.0 or Z2.5. Considering the application of Z-values, it makes more sense to compute both at the same time without needing to relying on user input.

Also changed the definition of -o argument. It was originally meant "output path" including the file name, but the default value was "."  So when -o is not specified, it will try to save the output to a file "." and crash.

Fixed such that -o now represents outdir, and the output file name inherits the ll file (with .z extension). The default outdir is the current directory, not the location of the .ll file. This is intentional as we don't want to accidentally overwrite the existing .z file in the StationInfo directory.


