### PR TITLE
Updated basins.yaml and fixed outline files

### DIFF
--- a/Data/basins.yaml
+++ b/Data/basins.yaml
@@ -7,7 +7,7 @@
     - id: 2
       name: North Canterbury
       files:
-        - Boundaries/NewCanterburyBasinBoundary_WGS84_1m.txt
+        - Data/SI_BASINS/NorthCanterbury_Polygon_WGS84.txt
     - id: 3
       name: Banks Peninsula Volcanics
       files:
@@ -36,7 +36,7 @@
     - id: 9
       name: Wellington / Hutt Valley
       files:
-        - Basins/Wellington/v19p6/Wellington_Polygon_Wainuiomata_WGS84.txt
+        - Data/Basins/Wellington/v21p8/Wellington_Polygon_Wainuiomata_WGS84.txt
     - id: 10
       name: Waikato / Hauraki
       files:
@@ -143,6 +143,8 @@
     name: Porirua
     files:
       - Basins/Greater_Wellington_and_Porirua/v21p7/Porirua1_Outline_WGS84.dat
+      - Basins/Greater_Wellington_and_Porirua/v21p7/Porirua2_Outline_WGS84.dat
+
   - id: 30
     name: Gisborne
     files:


### PR DESCRIPTION
I have been drafting a wiki page on the status of basins NZVM integration to keep things up-to-date.
https://wiki.canterbury.ac.nz/display/QuakeCore/NZVM+Basin+Data

Basin data is structured in Data folder in a rather messy fashion (scattered in Basins, Boundaries, Canterbury_Basin, NI_BASINS, SI_BASINS, USER20_BASINS directories), and then their paths are hard-coded in C source code.
![image](https://github.com/ucgmsim/Velocity-Model/assets/466989/e616a398-01c6-43e0-8773-9cc5f5928901)

We have an external process of updating Z-values that relies on NZVM and the location (esp. boundary) of basins, and it was frustrating to locate the relevant basin outline files from the C code.
This recent PR gives some context: https://github.com/ucgmsim/mapping/pull/10

I have isolated basin outline file paths and created basins.yaml file. At the moment, its usage is limited and NZVM is unaware of this, but consider this as the preparationwork to divorce data, config from the code.

This particular PR is a fix to basins.yaml with updated basin outline file paths.
